### PR TITLE
refactor: move Header to App.vue and fix gsap.set mock (#2)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import Header from "./components/Header.vue";
 import Hero from "./components/Hero.vue";
 </script>
 
 <template>
-  <Hero />
+  <Header />
+  <main>
+    <Hero />
+  </main>
 </template>
 
 <style scoped></style>

--- a/src/components/Hero.vue
+++ b/src/components/Hero.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { onMounted, nextTick } from "vue";
 import { gsap } from "gsap";
-import Header from "./Header.vue";
 
 onMounted(async () => {
   await nextTick();
@@ -31,7 +30,7 @@ onMounted(async () => {
       duration: 1.4,
       ease: "power2.out",
       delay: 0.9,
-    }
+    },
   );
 
   const button = document.querySelector(".hero-button");
@@ -57,7 +56,6 @@ onMounted(async () => {
 </script>
 
 <template>
-  <Header />
   <section id="hero" class="hero-section">
     <video class="hero-video" autoplay muted loop playsinline>
       <source src="/videos/skincare_02.mp4" type="video/mp4" />

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -9,6 +9,7 @@ vi.mock("gsap", () => {
       from: vi.fn(),
       fromTo: vi.fn(),
       to: vi.fn(),
+      set: vi.fn(),
     },
   };
 });


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige la jerarquía semántica de componentes moviendo Header 
de Hero.vue a App.vue, y añade gsap.set al mock de tests.

## Archivos modificados
- `src/App.vue` — monta Header y Hero como hermanos
- `src/components/Hero.vue` — elimina import y uso de Header
- `src/tests/setup.ts` — añade gsap.set al mock de GSAP

## Verificación
- [x] npm run dev — Header visible y funcional en browser
- [x] npm run test — 7 passed, 0 errors

## Cierra
Resolves #2